### PR TITLE
Fix execWithAddr not having a final return statement

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -273,6 +273,7 @@ func (c *Client) execWithAddr(urp bool, srv ServerInfo, a ...interface{}) (v int
 	} else {
 		return c.execute(cn.rw, a...)
 	}
+	return
 }
 
 // execute sends a command to redis, then reads and parses the response.


### PR DESCRIPTION
I was trying to use go-redis but was getting an error about the execWithAddr function not having a return statement at the end.
