### PR TITLE
Introduce Lrem

### DIFF
--- a/redis/commands.go
+++ b/redis/commands.go
@@ -669,6 +669,15 @@ func (c *Client) LRange(key string, begin, end int) ([]string, error) {
 	return iface2vstr(v), nil
 }
 
+// http://redis.io/commands/lrem
+func (c *Client) LRem(key string, count int, value string) (int, error) {
+	v, err := c.execWithKey(true, "LREM", key, count, value)
+	if err != nil {
+		return 0, err
+	}
+	return iface2int(v)
+}
+
 // http://redis.io/commands/hget
 func (c *Client) HGet(key, member string) (string, error) {
 	v, err := c.execWithKey(true, "HGET", key, member)

--- a/redis/commands_test.go
+++ b/redis/commands_test.go
@@ -190,6 +190,24 @@ func TestLRange(t *testing.T) {
 	}
 }
 
+func TestLRem(t *testing.T) {
+	rc.Del("list1")
+	defer rc.Del("list1")
+	rc.RPush("list1", "a", "b", "c", "d", "c")
+
+	if v, err := rc.LRem("list1", 2, "c"); err != nil {
+		t.Fatal(err)
+	} else if v != 2 {
+		t.Fatalf(errUnexpected, "LRem test1 return value")
+	}
+
+	if v, err := rc.LLen("list1"); err != nil {
+		t.Fatal(err)
+	} else if v != 3 {
+		t.Fatalf(errUnexpected, "LRem test1 length")
+	}
+}
+
 // TestBLPop reproduces the example from http://redis.io/commands/blpop.
 func TestBLPop(t *testing.T) {
 	rc.Del("list1", "list2")


### PR DESCRIPTION
I implemented [LREM](http://redis.io/commands/lrem) because I needed it for my first Go project.  It has the signature `LRem(key string, count int, value string) (int, error)` where `key` is a Redis list and `count` is the number of elements to delete, provided they are equal to `value`.  It returns the number of affected elements.
